### PR TITLE
Backwards-incompatible! docker::image: extra_systemd_parameters: support all unit sections

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -658,7 +658,7 @@ require 'spec_helper'
     end
 
     context 'with extra_systemd_parameters' do
-      let(:params) { {'command' => 'command', 'image' => 'base', 'extra_systemd_parameters' => {'RestartSec' => 5}} }
+      let(:params) { {'command' => 'command', 'image' => 'base', 'extra_systemd_parameters' => { 'Service' => {'RestartSec' => 5}}} }
       if (systemd)
         it { should contain_file(initscript).with_content(/^RestartSec=5$/) }
       end

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -16,6 +16,11 @@ Description=Daemon for <%= @title %>
 After=<%= @after.uniq.join(" ") %>
 Wants=<%= @wants.uniq.join(" ") %>
 Requires=<%= @requires.uniq.join(" ") %>
+<%- if @extra_systemd_parameters['Unit'] -%>
+<%- @extra_systemd_parameters['Unit'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
+<%- end -%>
 
 [Service]
 Restart=on-failure
@@ -33,8 +38,11 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
     <%= @image %> \
     <% if @command %> <%= @command %><% end %>
 <% end -%>
-<% @extra_systemd_parameters.each do |key, value| -%><%= key %>=<%= value %>
-<% end -%>
+<%- if @extra_systemd_parameters['Service'] -%>
+<%- @extra_systemd_parameters['Service'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
+<%- end -%>
 <%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
 <%- if @remove_container_on_start %>
@@ -54,3 +62,8 @@ ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>
 
 [Install]
 WantedBy=multi-user.target
+<%- if @extra_systemd_parameters['Install'] -%>
+<%- @extra_systemd_parameters['Install'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
This commit backports new backwards-incompatible behavior of extra_systemd_parameters from puppetlabs/puppetlabs-docker which would simplify transition