### PR TITLE
Fix docker network inspect parsing

### DIFF
--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -37,7 +37,8 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
 			_, name, driver = line.split(' ')
 			inspect = docker(['network', 'inspect', name])
 			obj = JSON.parse(inspect).first
-			subnet = unless obj['IPAM']['Config'].empty?
+			subnet = unless (obj['IPAM']['Config'].nil? || 
+				obj['IPAM']['Config'].empty?)
 				if obj['IPAM']['Config'].first.key? 'Subnet'
 					obj['IPAM']['Config'].first['Subnet']
 				end


### PR DESCRIPTION
Since docker version >= 25,  ["IPAM"]["Config"] can be 'null'  

```
"IPAM": {
    "Driver": "default",
    "Options": null,
    "Config": null,
},
```